### PR TITLE
Update Where we pull GPG key from.

### DIFF
--- a/tasks/install.deb.yml
+++ b/tasks/install.deb.yml
@@ -3,7 +3,7 @@
 - name: Add OpenVPN repo GPG key
   apt_key:
     id: E158C569
-    url: https://swupdate.openvpn.net/repos/repo-public.gpg
+    keyserver: keyserver.ubuntu.com
   when: openvpn_use_external_repo
 
 - name: Add OpenVPN repo sources


### PR DESCRIPTION
Moving From https cause external https server is returning a 403 forbidden from GCP